### PR TITLE
feat(hwclock): Allow to disable sync from sys to hardware clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ systemd with timesyncd compiled in
 
 ## Role Variables
 
-| Name                          | Default/Required      | Description                                         |
-|-------------------------------|:---------------------:|-----------------------------------------------------|
-| `timesync_timezone`           | `Etc/UTC`             | Timezone to set (relative to `/usr/share/zoneinfo`) |
-| `timesync_ntp_hosts`          |                       | Array of NTP hosts                                  |
-| `timesync_fallback_ntp_hosts` | `{0..3}.pool.ntp.org` | Array of fallback NTP hosts                         |
+| Name                               |   Default/Required    | Description                                                                       |
+| ---------------------------------- | :-------------------: | --------------------------------------------------------------------------------- |
+| `timesync_timezone`                |       `Etc/UTC`       | Timezone to set (relative to `/usr/share/zoneinfo`)                               |
+| `timesync_ntp_hosts`               |                       | Array of NTP hosts                                                                |
+| `timesync_fallback_ntp_hosts`      | `{0..3}.pool.ntp.org` | Array of fallback NTP hosts                                                       |
+| `timesync_write_hwclock_on_change` |        `True`         | Whether to write the time to the hardware clock after changing the configuration. |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ timesync_fallback_ntp_hosts:
   - 1.pool.ntp.org
   - 2.pool.ntp.org
   - 3.pool.ntp.org
+timesync_write_hwclock_on_change: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,5 +7,5 @@
 
 - name: Write adjtime
   command: hwclock --systohc
-  when: ansible_virtualization_role == "host" or ansible_virtualization_role == "NA"
+  when: (ansible_virtualization_role == "host" or ansible_virtualization_role == "NA") and timesync_write_hwclock_on_change
   listen: systemd-timesyncd configuration changed


### PR DESCRIPTION
This is required to prevent error on devices without hw clock (like pis)