### PR TITLE
Install systemd-timesyncd before configuring it - the correct way

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This role sets the timezone and configures and enables systemd-timesyncd.
 
 ## Requirements
 
-systemd with timesyncd compiled in
+systemd
 
 ## Role Variables
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This role sets the timezone and configures and enables systemd-timesyncd.
 
 ## Requirements
 
-debian
+systemd with timesyncd compiled in
 
 ## Role Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: Check if systemd-timesyncd can be installed
-  shell: aptitude -q search 'systemd-timesyncd'
-  register: installable
-  failed_when: installable.rc != 0 and installable.rc != 1
-  changed_when: False
-
-- name: Install systemd-timesyncd
-  apt:
-    name: systemd-timesyncd
-  when: installable.rc == 0
-
 - name: Set timezone
   timezone:
     name: "{{ timesync_timezone }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
+- set_fact:
+    pkg_name: "{{ 'systemd' if (ansible_distribution == 'Debian' and ansible_distribution_major_version is version('10', '<=')) else 'systemd-timesyncd' }}"
+
 - name: Install systemd-timesyncd
   package:
-    name: systemd-timesyncd
+    name: "{{ pkg_name }}"
 
 - name: Set timezone
   timezone:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install systemd-timesyncd
+  package:
+    name: systemd-timesyncd
+
 - name: Set timezone
   timezone:
     name: "{{ timesync_timezone }}"


### PR DESCRIPTION
The change introduced in dac573c was wrong:
      - it was debian-specific
      - it required aptitude (which is not installed by default even on Debian-based distros)
      - it checked if package can be installed, but the it assumed it is
    
The correct way to do this is to just use the system package manager to install the package unconditionally.

This PR reverts the errorneous commit and fixes the original issue.