### PR TITLE
Create drop-in configuration file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,18 @@
     name: "{{ timesync_timezone }}"
   notify: systemd-timesyncd configuration changed
 
+- name: Create systemd-timesyncd.conf.d
+  file:
+    path: /etc/systemd/timesyncd.conf.d
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
 - name: Configure systemd-timesyncd
   template:
     src: timesyncd.conf.j2
-    dest: /etc/systemd/timesyncd.conf
+    dest: /etc/systemd/timesyncd.conf.d/local.conf
     mode: 0644
     owner: root
     group: root


### PR DESCRIPTION
Drop-in configuration have higher precedence and will override the main configuration file, which could be used for `systemd-timesyncd`.

> In addition to the "main" configuration file, drop-in configuration snippets are read from /usr/lib/systemd/*.conf.d/, /usr/local/lib/systemd/*.conf.d/, and /etc/systemd/*.conf.d/.
[man timesyncd.conf](https://man.archlinux.org/man/timesyncd.conf.5)

