### PR TITLE
Use FQCN for builtin module actions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: Install systemd-timesyncd
-  package:
+  ansible.builtin.package:
     name: systemd-timesyncd
   when: not ((ansible_distribution == 'Debian' and ansible_distribution_major_version is version('11', '<')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('20', '<')) or ansible_distribution == 'Archlinux')
 
 - name: Set timezone
-  timezone:
+  community.general.timezone:
     name: "{{ timesync_timezone }}"
   notify: systemd-timesyncd configuration changed
 
 - name: Create systemd-timesyncd.conf.d
-  file:
+  ansible.builtin.file:
     path: /etc/systemd/timesyncd.conf.d
     state: directory
     mode: 0755
@@ -18,7 +18,7 @@
     group: root
 
 - name: Configure systemd-timesyncd
-  template:
+  ansible.builtin.template:
     src: timesyncd.conf.j2
     dest: /etc/systemd/timesyncd.conf.d/local.conf
     mode: 0644
@@ -27,7 +27,7 @@
   notify: systemd-timesyncd configuration changed
 
 - name: Start and enable systemd-timesyncd
-  service:
+  ansible.builtin.service:
     name: systemd-timesyncd.service
-    enabled: yes
+    enabled: true
     state: started


### PR DESCRIPTION
https://ansible.readthedocs.io/projects/lint/rules/fqcn/

```
ansible-lint timesyncd.yml 

Passed: 0 failure(s), 0 warning(s) on 13 files. Last profile that met the validation criteria was 'production'.
```