### PR TITLE
install hwclock utility if missing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure hwclock is installed
+  package:
+    name:
+      - util-linux-extra # hwclock is not installed by default in Ubuntu 24.04LTS
+    state: present
+  become: yes
+
 - name: Install systemd-timesyncd
   package:
     name: systemd-timesyncd


### PR DESCRIPTION
at least Ubuntu 24.04 has hwclock not installed by default, therefore this playbook will fail.

- a defensive way to handle this is to ensure "util-linux-extra" is installed. 
- this will not affect older versions, where package is installed by default. 
